### PR TITLE
Ereg integrasjon

### DIFF
--- a/src/main/kotlin/no/nav/familie/ef/proxy/api/ApiExceptionHandler.kt
+++ b/src/main/kotlin/no/nav/familie/ef/proxy/api/ApiExceptionHandler.kt
@@ -80,7 +80,7 @@ class ApiExceptionHandler : ResponseEntityExceptionHandler() {
                 " status=$status"
 
         loggFeil(throwable, loggMelding)
-        return ResponseEntity.status(status).body(FeilDto("Håntert feil"))
+        return ResponseEntity.status(status).body(FeilDto("Håndtert feil"))
     }
 
     private fun loggFeil(throwable: Throwable, loggMelding: String) {

--- a/src/main/kotlin/no/nav/familie/ef/proxy/ereg/EregClient.kt
+++ b/src/main/kotlin/no/nav/familie/ef/proxy/ereg/EregClient.kt
@@ -21,15 +21,8 @@ class EregClient(
         val organisasjoner = mutableListOf<Map<String, Any>>()
 
         organisasjonsnumre.forEach {
-            organisasjoner.add(getForEntity(UriComponentsBuilder.fromUri(uri).pathSegment(it).build().toUri(), headers()))
+            organisasjoner.add(getForEntity(UriComponentsBuilder.fromUri(uri).pathSegment(it).build().toUri()))
         }
         return organisasjoner
-    }
-
-    private fun headers(): HttpHeaders {
-        return HttpHeaders().apply {
-            contentType = MediaType.APPLICATION_JSON
-            accept = listOf(MediaType.APPLICATION_JSON)
-        }
     }
 }

--- a/src/main/kotlin/no/nav/familie/ef/proxy/ereg/EregClient.kt
+++ b/src/main/kotlin/no/nav/familie/ef/proxy/ereg/EregClient.kt
@@ -17,14 +17,13 @@ class EregClient(
     @Qualifier("sts") restOperations: RestOperations
 ) : AbstractRestClient(restOperations, "ereg") {
 
-    private val logger = LoggerFactory.getLogger(this::class.java)
+    fun hentOrganisasjoner(organisasjonsnumre: List<String>): List<Map<String, Any>> {
+        val organisasjoner = mutableListOf<Map<String, Any>>()
 
-    fun hentOrganisasjoner(organisasjonsnumre: List<String>): List<Organisasjon> {
-        logger.info("Kaller: ${UriComponentsBuilder.fromUri(uri).pathSegment(organisasjonsnumre.first()).build()}")
-
-        return organisasjonsnumre.map {
-            Organisasjon(it, getForEntity(UriComponentsBuilder.fromUri(uri).pathSegment(it).build().toUri(), headers()))
-        }.toList()
+        organisasjonsnumre.forEach {
+            organisasjoner.add(getForEntity(UriComponentsBuilder.fromUri(uri).pathSegment(it).build().toUri(), headers()))
+        }
+        return organisasjoner
     }
 
     private fun headers(): HttpHeaders {
@@ -34,8 +33,3 @@ class EregClient(
         }
     }
 }
-
-data class Organisasjon(
-    val orgnr : String,
-    val response: Map<String, Any>
-)

--- a/src/main/kotlin/no/nav/familie/ef/proxy/ereg/EregClient.kt
+++ b/src/main/kotlin/no/nav/familie/ef/proxy/ereg/EregClient.kt
@@ -1,6 +1,7 @@
 package no.nav.familie.ef.proxy.ereg
 
 import no.nav.familie.http.client.AbstractRestClient
+import org.slf4j.LoggerFactory
 import org.springframework.beans.factory.annotation.Qualifier
 import org.springframework.beans.factory.annotation.Value
 import org.springframework.http.HttpHeaders
@@ -16,8 +17,11 @@ class EregClient(
     @Qualifier("sts") restOperations: RestOperations
 ) : AbstractRestClient(restOperations, "ereg") {
 
+    private val logger = LoggerFactory.getLogger(this::class.java)
 
     fun hentOrganisasjoner(organisasjonsnumre: List<String>): List<Organisasjon> {
+        logger.info("Kaller: ${UriComponentsBuilder.fromUri(uri).pathSegment(organisasjonsnumre.first()).build()}")
+
         return organisasjonsnumre.map {
             Organisasjon(it, getForEntity(UriComponentsBuilder.fromUri(uri).pathSegment(it).build().toUri(), headers()))
         }.toList()

--- a/src/main/kotlin/no/nav/familie/ef/proxy/ereg/EregClient.kt
+++ b/src/main/kotlin/no/nav/familie/ef/proxy/ereg/EregClient.kt
@@ -1,0 +1,37 @@
+package no.nav.familie.ef.proxy.ereg
+
+import no.nav.familie.http.client.AbstractRestClient
+import org.springframework.beans.factory.annotation.Qualifier
+import org.springframework.beans.factory.annotation.Value
+import org.springframework.http.HttpHeaders
+import org.springframework.http.MediaType
+import org.springframework.stereotype.Component
+import org.springframework.web.client.RestOperations
+import org.springframework.web.util.UriComponentsBuilder
+import java.net.URI
+
+@Component
+class EregClient(
+    @Value("\${EREG_URL}") private val uri: URI,
+    @Qualifier("sts") restOperations: RestOperations
+) : AbstractRestClient(restOperations, "ereg") {
+
+
+    fun hentOrganisasjoner(organisasjonsnumre: List<String>): List<Organisasjon> {
+        return organisasjonsnumre.map {
+            Organisasjon(it, getForEntity(UriComponentsBuilder.fromUri(uri).pathSegment(it).build().toUri(), headers()))
+        }.toList()
+    }
+
+    private fun headers(): HttpHeaders {
+        return HttpHeaders().apply {
+            contentType = MediaType.APPLICATION_JSON
+            accept = listOf(MediaType.APPLICATION_JSON)
+        }
+    }
+}
+
+data class Organisasjon(
+    val orgnr : String,
+    val response: Map<String, Any>
+)

--- a/src/main/kotlin/no/nav/familie/ef/proxy/ereg/EregController.kt
+++ b/src/main/kotlin/no/nav/familie/ef/proxy/ereg/EregController.kt
@@ -4,8 +4,8 @@ import no.nav.security.token.support.core.api.ProtectedWithClaims
 import org.springframework.http.MediaType
 import org.springframework.validation.annotation.Validated
 import org.springframework.web.bind.annotation.GetMapping
-import org.springframework.web.bind.annotation.RequestBody
 import org.springframework.web.bind.annotation.RequestMapping
+import org.springframework.web.bind.annotation.RequestParam
 import org.springframework.web.bind.annotation.RestController
 
 @RestController
@@ -17,7 +17,7 @@ import org.springframework.web.bind.annotation.RestController
 class EregController(private val eregClient: EregClient) {
 
     @GetMapping
-    fun hentOrganisasjon(@RequestBody organisasjonsnumre: List<String>): List<Map<String, Any>> {
+    fun hentOrganisasjon(@RequestParam organisasjonsnumre: List<String>): List<Map<String, Any>> {
         return eregClient.hentOrganisasjoner(organisasjonsnumre)
     }
 

--- a/src/main/kotlin/no/nav/familie/ef/proxy/ereg/EregController.kt
+++ b/src/main/kotlin/no/nav/familie/ef/proxy/ereg/EregController.kt
@@ -1,0 +1,24 @@
+package no.nav.familie.ef.proxy.ereg
+
+import no.nav.security.token.support.core.api.ProtectedWithClaims
+import org.springframework.http.MediaType
+import org.springframework.validation.annotation.Validated
+import org.springframework.web.bind.annotation.PostMapping
+import org.springframework.web.bind.annotation.RequestBody
+import org.springframework.web.bind.annotation.RequestMapping
+import org.springframework.web.bind.annotation.RestController
+
+@RestController
+@RequestMapping("/api/ereg",
+    consumes = [MediaType.APPLICATION_JSON_VALUE],
+    produces = [MediaType.APPLICATION_JSON_VALUE])
+@ProtectedWithClaims(issuer = "azuread")
+@Validated
+class EregController(private val eregClient: EregClient) {
+
+    @PostMapping
+    fun hentOrganisasjon(@RequestBody organisasjonsnumre: List<String>): List<Organisasjon> {
+        return eregClient.hentOrganisasjoner(organisasjonsnumre)
+    }
+
+}

--- a/src/main/kotlin/no/nav/familie/ef/proxy/ereg/EregController.kt
+++ b/src/main/kotlin/no/nav/familie/ef/proxy/ereg/EregController.kt
@@ -3,7 +3,7 @@ package no.nav.familie.ef.proxy.ereg
 import no.nav.security.token.support.core.api.ProtectedWithClaims
 import org.springframework.http.MediaType
 import org.springframework.validation.annotation.Validated
-import org.springframework.web.bind.annotation.PostMapping
+import org.springframework.web.bind.annotation.GetMapping
 import org.springframework.web.bind.annotation.RequestBody
 import org.springframework.web.bind.annotation.RequestMapping
 import org.springframework.web.bind.annotation.RestController
@@ -16,7 +16,7 @@ import org.springframework.web.bind.annotation.RestController
 @Validated
 class EregController(private val eregClient: EregClient) {
 
-    @PostMapping
+    @GetMapping
     fun hentOrganisasjon(@RequestBody organisasjonsnumre: List<String>): List<Map<String, Any>> {
         return eregClient.hentOrganisasjoner(organisasjonsnumre)
     }

--- a/src/main/kotlin/no/nav/familie/ef/proxy/ereg/EregController.kt
+++ b/src/main/kotlin/no/nav/familie/ef/proxy/ereg/EregController.kt
@@ -17,7 +17,7 @@ import org.springframework.web.bind.annotation.RestController
 class EregController(private val eregClient: EregClient) {
 
     @PostMapping
-    fun hentOrganisasjon(@RequestBody organisasjonsnumre: List<String>): List<Organisasjon> {
+    fun hentOrganisasjon(@RequestBody organisasjonsnumre: List<String>): List<Map<String, Any>> {
         return eregClient.hentOrganisasjoner(organisasjonsnumre)
     }
 

--- a/src/main/resources/application-dev.yml
+++ b/src/main/resources/application-dev.yml
@@ -7,5 +7,5 @@ no.nav.security.jwt:
 
 GCP_ENV: dev
 EF_SAK_URL: https://familie-ef-sak.dev.intern.nav.no
-
+EREG_URL: https://modapp-q2.adeo.no/ereg/api
 INNTEKT_URL: https://app-q2.adeo.no/inntektskomponenten-ws/rs/api

--- a/src/main/resources/application-dev.yml
+++ b/src/main/resources/application-dev.yml
@@ -7,5 +7,5 @@ no.nav.security.jwt:
 
 GCP_ENV: dev
 EF_SAK_URL: https://familie-ef-sak.dev.intern.nav.no
-EREG_URL: https://modapp-q2.adeo.no/ereg/api
+EREG_URL: https://modapp-q2.adeo.no/ereg/api/organisasjon
 INNTEKT_URL: https://app-q2.adeo.no/inntektskomponenten-ws/rs/api

--- a/src/main/resources/application-dev.yml
+++ b/src/main/resources/application-dev.yml
@@ -7,5 +7,5 @@ no.nav.security.jwt:
 
 GCP_ENV: dev
 EF_SAK_URL: https://familie-ef-sak.dev.intern.nav.no
-EREG_URL: https://modapp-q2.adeo.no/ereg/api/organisasjon
+EREG_URL: https://modapp-q2.adeo.no/ereg/api/v1/organisasjon
 INNTEKT_URL: https://app-q2.adeo.no/inntektskomponenten-ws/rs/api

--- a/src/main/resources/application.yml
+++ b/src/main/resources/application.yml
@@ -44,7 +44,7 @@ management:
 
 GCP_ENV: prod
 EF_SAK_URL: https://familie-ef-sak.intern.nav.no
-
+EREG_URL: https://modapp.adeo.no/ereg/api/v1/organisasjon
 INNTEKT_URL: https://app.adeo.no/inntektskomponenten-ws/rs/api
 
 STS_PREFIX: http://security-token-service.default


### PR DESCRIPTION
Gjort klar endepunkt for kall mot ereg. Endepunktet skal brukes av ef-sak til å vise organisasjonsnavn i inntektsoversikt.
Skal forbedre ytelsen ved å gjøre mange async kall i egen PR, da ereg-apiet ikke hadde eget endepunkt som tok flere orgnumre. 
Merges før: https://github.com/navikt/familie-ef-sak/pull/932

