### PR TITLE
Ereg-controller skal ikke kreve json

### DIFF
--- a/src/main/kotlin/no/nav/familie/ef/proxy/ereg/EregController.kt
+++ b/src/main/kotlin/no/nav/familie/ef/proxy/ereg/EregController.kt
@@ -10,7 +10,6 @@ import org.springframework.web.bind.annotation.RestController
 
 @RestController
 @RequestMapping("/api/ereg",
-    consumes = [MediaType.APPLICATION_JSON_VALUE],
     produces = [MediaType.APPLICATION_JSON_VALUE])
 @ProtectedWithClaims(issuer = "azuread")
 @Validated


### PR DESCRIPTION
`consumes = [MediaType.APPLICATION_JSON_VALUE]` gir vel ikke mening for en kontroller som kun har en get-mapping?