### PR TITLE
Skal være GET-kall mot Sigrun

### DIFF
--- a/src/main/kotlin/no/nav/familie/ef/proxy/sigrun/SigrunClient.kt
+++ b/src/main/kotlin/no/nav/familie/ef/proxy/sigrun/SigrunClient.kt
@@ -23,7 +23,7 @@ class SigrunClient(
         headers.set("x-filter", "BeregnetSkattPensjonsgivendeInntekt")
         headers.set("x-naturligident", personIdent)
         headers.set("x-inntektsaar", inntektsår.toString())
-        return postForEntity(uriComponentsBuilder.build().toUri(), mapOf("fnr" to personIdent), headers)
+        return getForEntity(uriComponentsBuilder.build().toUri(), headers)
     }
 
     fun hentSummertSkattegrunnlag(personIdent: String, inntektsår: Int): Map<String, Any> {
@@ -34,6 +34,6 @@ class SigrunClient(
         val headers = HttpHeaders()
         headers.set("x-naturligident", personIdent)
 
-        return postForEntity(uriComponentsBuilder.build().toUri(), mapOf("fnr" to personIdent), headers)
+        return getForEntity(uriComponentsBuilder.build().toUri(), headers)
     }
 }

--- a/src/main/resources/application-dev.yml
+++ b/src/main/resources/application-dev.yml
@@ -12,7 +12,7 @@ CLUSTER_ENV: dev
 EF_SAK_URL: https://familie-ef-sak.dev.intern.nav.no
 EREG_URL: https://modapp-q2.adeo.no/ereg/api/v1/organisasjon
 INNTEKT_URL: https://app-q2.adeo.no/inntektskomponenten-ws/rs/api
-SIGRUN_URL: https://sigrun-q2.nais.preprod.local/api/
+SIGRUN_URL: https://sigrun-q2.dev.adeo.no/api/
 ARBEID_INNTEKT_URL: https://arbeid-og-inntekt.dev.adeo.no
 ARBEIDSSØKER_URL: https://veilarbregistrering.dev.intern.nav.no/veilarbregistrering/api
 STS_URL: https://security-token-service.nais.preprod.local/rest/v1/sts/token


### PR DESCRIPTION
Gjør om til GET-kall, da kun det støttes i Sigrun.
Litt dumt at det blir post mot proxy, når det er GET senere, men vil ikke sende med fødselsnummer i header, så det får bli en post med fnr i request body.

https://favro.com/organization/98c34fb974ce445eac854de0/a64c6aad9b0d61ef6c0290bd?card=NAV-8724