### PR TITLE
Fjern CPU-limit

### DIFF
--- a/.deploy/nais-dev.yaml
+++ b/.deploy/nais-dev.yaml
@@ -22,11 +22,9 @@ spec:
   replicas:
     min: 2
     max: 3
-    cpuThresholdPercentage: 50
   resources:
     limits:
       memory: 256Mi
-      cpu: 500m
     requests:
       memory: 256Mi
       cpu: 500m

--- a/.deploy/nais-prod.yaml
+++ b/.deploy/nais-prod.yaml
@@ -22,11 +22,9 @@ spec:
   replicas:
     min: 2
     max: 3
-    cpuThresholdPercentage: 50
   resources:
     limits:
       memory: 512Mi
-      cpu: 1000m
     requests:
       memory: 256Mi
       cpu: 500m


### PR DESCRIPTION
Anbefaling fra NAIS om at CPU throttle fjernes fra pod, men beholdes for requests: https://nav-it.slack.com/archives/C01DE3M9YBV/p1680172494569329

Artikkelen som det refereres til i meldingen fra NAIS beskriver hvorfor:
https://home.robusta.dev/blog/stop-using-cpu-limits

[Favro](https://favro.com/organization/98c34fb974ce445eac854de0/a64c6aad9b0d61ef6c0290bd?card=NAV-12306)