### PR TITLE
Genererer url for å se arbeidsforhold for gitt personident

### DIFF
--- a/src/main/kotlin/no/nav/familie/ef/proxy/ainntekt/ArbeidOgInntektClient.kt
+++ b/src/main/kotlin/no/nav/familie/ef/proxy/ainntekt/ArbeidOgInntektClient.kt
@@ -18,6 +18,9 @@ class ArbeidOgInntektClient(
     private val redirectUri = UriComponentsBuilder.fromUri(uri)
         .pathSegment("api/v2/redirect/sok/a-inntekt").build().toUri()
 
+    private val redirectUriArbeidsforhold = UriComponentsBuilder.fromUri(uri)
+        .pathSegment("api/v2/redirect/sok/arbeidstaker").build().toUri()
+
     fun hentUrlTilArbeidOgInntekt(personIdent: String): String {
         return getForEntity(
             redirectUri,
@@ -25,6 +28,16 @@ class ArbeidOgInntektClient(
                 accept = listOf(MediaType.TEXT_PLAIN)
                 set("Nav-Personident", personIdent)
             },
+        )
+    }
+
+    fun hentUrlTilArbeidsforhold(personIdent: String): String {
+        return getForEntity(
+            redirectUriArbeidsforhold,
+            HttpHeaders().apply {
+                accept = listOf(MediaType.TEXT_PLAIN)
+                set("Nav-Personident", personIdent)
+            }
         )
     }
 }

--- a/src/main/kotlin/no/nav/familie/ef/proxy/ainntekt/ArbeidOgInntektController.kt
+++ b/src/main/kotlin/no/nav/familie/ef/proxy/ainntekt/ArbeidOgInntektController.kt
@@ -22,4 +22,9 @@ class ArbeidOgInntektController(private val client: ArbeidOgInntektClient) {
     fun hentUrlTilArbeidOgInntekt(@RequestBody request: PersonIdent): String {
         return client.hentUrlTilArbeidOgInntekt(request.ident)
     }
+
+    @PostMapping("generer-url-arbeidsforhold")
+    fun hentUrlTilArbeidOgInntektArbeidsforhold(@RequestBody personIdent: PersonIdent): String {
+        return client.hentUrlTilArbeidsforhold(personIdent.ident)
+    }
 }


### PR DESCRIPTION
For å vise arbeidsforhold for gitt person i a-inntekt må det gjøres et kall for å få en lenke. 
Dette endepunktet skal brukes i behandlinger der bruker har et avsluttet arbeidsforhold i aareg siste 6 mnd
Hører til PR i [familie-ef-sak](https://github.com/navikt/familie-ef-sak/pull/2365)

[Favro](https://favro.com/organization/98c34fb974ce445eac854de0/a64c6aad9b0d61ef6c0290bd?card=NAV-11500)