### PR TITLE
Hent pensjonsgivende inntekt

### DIFF
--- a/.github/workflows/deploy-dev.yml
+++ b/.github/workflows/deploy-dev.yml
@@ -10,6 +10,8 @@ jobs:
   build:
     name: Build, push and deploy to dev-fss
     runs-on: ubuntu-latest
+    permissions:
+      packages: "write"
     steps:
       - uses: actions/checkout@v4
         with:

--- a/.github/workflows/deploy-prod.yml
+++ b/.github/workflows/deploy-prod.yml
@@ -12,6 +12,8 @@ jobs:
   build:
     name: Build, push and deploy to dev-fss and prod-fss
     runs-on: ubuntu-latest
+    permissions:
+      packages: "write"
     steps:
       - uses: actions/checkout@v4
         with:

--- a/src/main/kotlin/no/nav/familie/ef/proxy/sigrun/SigrunClient.kt
+++ b/src/main/kotlin/no/nav/familie/ef/proxy/sigrun/SigrunClient.kt
@@ -27,7 +27,7 @@ class SigrunClient(
             getForEntity(uriComponentsBuilder.build().toUri(), headers)
         } catch (e: HttpClientErrorException.NotFound) {
             secureLogger.warn(e.message)
-            emptyMap()
+            throw e
         }
     }
 

--- a/src/main/kotlin/no/nav/familie/ef/proxy/sigrun/SigrunClient.kt
+++ b/src/main/kotlin/no/nav/familie/ef/proxy/sigrun/SigrunClient.kt
@@ -16,6 +16,22 @@ class SigrunClient(
     @Qualifier("azure") restOperations: RestOperations,
 ) : AbstractRestClient(restOperations, "sigrun") {
 
+
+    fun hentPensjonsgivendeInntekt(personIdent: String, inntektsår: Int): List<Map<String, Any>> {
+        val uriComponentsBuilder = UriComponentsBuilder.fromUri(uri).pathSegment("v1/pensjonsgivendeinntekt")
+
+        val headers = HttpHeaders()
+        headers.set("Nav-Personident", personIdent)
+        headers.set("inntektsaar", inntektsår.toString())
+
+        return try {
+            getForEntity(uriComponentsBuilder.build().toUri(), headers)
+        } catch (e: HttpClientErrorException.NotFound) {
+            secureLogger.warn(e.message)
+            emptyList()
+        }
+    }
+
     fun hentBeregnetSkatt(personIdent: String, inntektsår: Int): List<Map<String, Any>> {
         val uriComponentsBuilder = UriComponentsBuilder.fromUri(uri).pathSegment("beregnetskatt")
             .queryParam("inntektsaar", inntektsår)

--- a/src/main/kotlin/no/nav/familie/ef/proxy/sigrun/SigrunClient.kt
+++ b/src/main/kotlin/no/nav/familie/ef/proxy/sigrun/SigrunClient.kt
@@ -17,7 +17,7 @@ class SigrunClient(
 ) : AbstractRestClient(restOperations, "sigrun") {
 
     fun hentPensjonsgivendeInntekt(personIdent: String, inntektsår: Int): List<Map<String, Any>> {
-        val uriComponentsBuilder = UriComponentsBuilder.fromUri(uri).pathSegment("v1/pensjonsgivendeinntekt")
+        val uriComponentsBuilder = UriComponentsBuilder.fromUri(uri).pathSegment("v1/pensjonsgivendeinntektforfolketrygden")
 
         val headers = HttpHeaders()
         headers.set("Nav-Personident", personIdent)

--- a/src/main/kotlin/no/nav/familie/ef/proxy/sigrun/SigrunClient.kt
+++ b/src/main/kotlin/no/nav/familie/ef/proxy/sigrun/SigrunClient.kt
@@ -16,7 +16,7 @@ class SigrunClient(
     @Qualifier("azure") restOperations: RestOperations,
 ) : AbstractRestClient(restOperations, "sigrun") {
 
-    fun hentPensjonsgivendeInntekt(personIdent: String, inntektsår: Int): List<Map<String, Any>> {
+    fun hentPensjonsgivendeInntekt(personIdent: String, inntektsår: Int): Map<String, Any> {
         val uriComponentsBuilder = UriComponentsBuilder.fromUri(uri).pathSegment("v1/pensjonsgivendeinntektforfolketrygden")
 
         val headers = HttpHeaders()
@@ -27,7 +27,7 @@ class SigrunClient(
             getForEntity(uriComponentsBuilder.build().toUri(), headers)
         } catch (e: HttpClientErrorException.NotFound) {
             secureLogger.warn(e.message)
-            emptyList()
+            emptyMap()
         }
     }
 

--- a/src/main/kotlin/no/nav/familie/ef/proxy/sigrun/SigrunClient.kt
+++ b/src/main/kotlin/no/nav/familie/ef/proxy/sigrun/SigrunClient.kt
@@ -16,7 +16,6 @@ class SigrunClient(
     @Qualifier("azure") restOperations: RestOperations,
 ) : AbstractRestClient(restOperations, "sigrun") {
 
-
     fun hentPensjonsgivendeInntekt(personIdent: String, inntektsår: Int): List<Map<String, Any>> {
         val uriComponentsBuilder = UriComponentsBuilder.fromUri(uri).pathSegment("v1/pensjonsgivendeinntekt")
 

--- a/src/main/kotlin/no/nav/familie/ef/proxy/sigrun/SigrunClient.kt
+++ b/src/main/kotlin/no/nav/familie/ef/proxy/sigrun/SigrunClient.kt
@@ -27,7 +27,7 @@ class SigrunClient(
             getForEntity(uriComponentsBuilder.build().toUri(), headers)
         } catch (e: HttpClientErrorException.NotFound) {
             secureLogger.warn(e.message)
-            throw e
+            emptyMap()
         }
     }
 

--- a/src/main/kotlin/no/nav/familie/ef/proxy/sigrun/SigrunController.kt
+++ b/src/main/kotlin/no/nav/familie/ef/proxy/sigrun/SigrunController.kt
@@ -21,6 +21,17 @@ import java.time.YearMonth
 @Validated
 class SigrunController(private val sigrunClient: SigrunClient) {
 
+    @PostMapping("/pensjonsgivendeinntekt")
+    fun hentPensjonsgivendeInntekt(
+        @RequestBody personIdent: PersonIdent,
+        @RequestParam("inntektsaar", required = false) inntektsår: Int?,
+    ): List<Map<String, Any>> {
+        return sigrunClient.hentPensjonsgivendeInntekt(
+            personIdent.ident,
+            inntektsår ?: (YearMonth.now().year - 1)
+        )
+    }
+
     @PostMapping("/beregnetskatt")
     fun hentBeregnetSkatt(
         @RequestBody personIdent: PersonIdent,

--- a/src/main/kotlin/no/nav/familie/ef/proxy/sigrun/SigrunController.kt
+++ b/src/main/kotlin/no/nav/familie/ef/proxy/sigrun/SigrunController.kt
@@ -28,7 +28,7 @@ class SigrunController(private val sigrunClient: SigrunClient) {
     ): List<Map<String, Any>> {
         return sigrunClient.hentPensjonsgivendeInntekt(
             personIdent.ident,
-            inntektsår ?: (YearMonth.now().year - 1)
+            inntektsår ?: (YearMonth.now().year - 1),
         )
     }
 

--- a/src/main/kotlin/no/nav/familie/ef/proxy/sigrun/SigrunController.kt
+++ b/src/main/kotlin/no/nav/familie/ef/proxy/sigrun/SigrunController.kt
@@ -25,7 +25,7 @@ class SigrunController(private val sigrunClient: SigrunClient) {
     fun hentPensjonsgivendeInntekt(
         @RequestBody personIdent: PersonIdent,
         @RequestParam("inntektsaar", required = false) inntektsår: Int?,
-    ): List<Map<String, Any>> {
+    ): Map<String, Any> {
         return sigrunClient.hentPensjonsgivendeInntekt(
             personIdent.ident,
             inntektsår ?: (YearMonth.now().year - 1),

--- a/src/main/resources/application-dev.yml
+++ b/src/main/resources/application-dev.yml
@@ -12,7 +12,7 @@ CLUSTER_ENV: dev
 EF_SAK_URL: https://familie-ef-sak.intern.dev.nav.no
 EREG_URL: https://modapp-q2.adeo.no/ereg/api/v1/organisasjon
 INNTEKT_URL: https://app-q2.adeo.no/inntektskomponenten-ws/rs/api
-SIGRUN_URL: https://sigrun-q2.dev.adeo.no/api/
+SIGRUN_URL: https://sigrun-skd-stub.dev.adeo.no/api
 ARBEID_INNTEKT_URL: https://arbeid-og-inntekt.dev.adeo.no
 STS_URL: https://security-token-service.nais.preprod.local/rest/v1/sts/token
 EF_PERSONHENDELSE_CLIENT_ID: dev-gcp:teamfamilie:familie-ef-personhendelse

--- a/src/test/kotlin/no/nav/familie/ef/proxy/sigrun/SigrunControllerTest.kt
+++ b/src/test/kotlin/no/nav/familie/ef/proxy/sigrun/SigrunControllerTest.kt
@@ -22,6 +22,20 @@ internal class SigrunControllerTest : IntegrationSpringRunnerTest() {
     }
 
     @Test
+    internal fun `kall pensjonsgivendeinntekt med inntektsaar`() {
+        val url = localhost("/api/sigrun/pensjonsgivendeinntekt?inntektsaar=2022")
+        val response = restTemplate.exchange<List<Map<String, String>>>(
+            url,
+            HttpMethod.POST,
+            HttpEntity(mapOf("ident" to "123"), headers),
+        )
+        Assertions.assertThat(response.statusCode).isEqualTo(HttpStatus.OK)
+        Assertions.assertThat(response.body!!).isEqualTo(emptyList<Map<String, Any>>())
+
+        verify(exactly = 1) { sigrunClient.hentPensjonsgivendeInntekt("123", 2022) }
+    }
+
+    @Test
     internal fun `kall beregnetskatt med inntektsaar`() {
         val url = localhost("/api/sigrun/beregnetskatt?inntektsaar=2020")
         val response = restTemplate.exchange<List<Map<String, String>>>(

--- a/src/test/kotlin/no/nav/familie/ef/proxy/sigrun/SigrunControllerTest.kt
+++ b/src/test/kotlin/no/nav/familie/ef/proxy/sigrun/SigrunControllerTest.kt
@@ -24,13 +24,13 @@ internal class SigrunControllerTest : IntegrationSpringRunnerTest() {
     @Test
     internal fun `kall pensjonsgivendeinntekt med inntektsaar`() {
         val url = localhost("/api/sigrun/pensjonsgivendeinntekt?inntektsaar=2022")
-        val response = restTemplate.exchange<List<Map<String, String>>>(
+        val response = restTemplate.exchange<Map<String, String>>(
             url,
             HttpMethod.POST,
             HttpEntity(mapOf("ident" to "123"), headers),
         )
         Assertions.assertThat(response.statusCode).isEqualTo(HttpStatus.OK)
-        Assertions.assertThat(response.body!!).isEqualTo(emptyList<Map<String, Any>>())
+        Assertions.assertThat(response.body!!).isEqualTo(emptyMap<String, Any>())
 
         verify(exactly = 1) { sigrunClient.hentPensjonsgivendeInntekt("123", 2022) }
     }

--- a/src/test/kotlin/no/nav/familie/ef/proxy/sigrun/SigrunTestConfig.kt
+++ b/src/test/kotlin/no/nav/familie/ef/proxy/sigrun/SigrunTestConfig.kt
@@ -15,7 +15,7 @@ class SigrunTestConfig {
     @Primary
     fun sigrunClient(): SigrunClient {
         val client = mockk<SigrunClient>()
-        every { client.hentPensjonsgivendeInntekt(any(), any()) } returns emptyList()
+        every { client.hentPensjonsgivendeInntekt(any(), any()) } returns emptyMap()
         every { client.hentBeregnetSkatt(any(), any()) } returns emptyList()
         every { client.hentSummertSkattegrunnlag(any(), any()) } returns emptyList()
         return client

--- a/src/test/kotlin/no/nav/familie/ef/proxy/sigrun/SigrunTestConfig.kt
+++ b/src/test/kotlin/no/nav/familie/ef/proxy/sigrun/SigrunTestConfig.kt
@@ -15,6 +15,7 @@ class SigrunTestConfig {
     @Primary
     fun sigrunClient(): SigrunClient {
         val client = mockk<SigrunClient>()
+        every { client.hentPensjonsgivendeInntekt(any(), any()) } returns emptyList()
         every { client.hentBeregnetSkatt(any(), any()) } returns emptyList()
         every { client.hentSummertSkattegrunnlag(any(), any()) } returns emptyList()
         return client


### PR DESCRIPTION
Henter pensjonsgivende inntekt fra Sigrun som skal vises i personoversikten. Det er koblet til sigrun-skd-stub i preprod inntil det er mulig å generere testdata i Dolly. Nå må testdata genereres via [Swagger-ui](https://sigrun-skd-stub.dev.adeo.no/swagger-ui/index.html?urls.primaryName=Endepunkter%20for%20testdata#/PensjonsgivendeInntektForFolketrygden-stub/opprett). 
Dersom det ikke finnes data for gitt person på gitt inntektsår returneres 404 fra Sigrun, dette catches her og det sendes heller med en tom response til ef-sak.

[Favro](https://favro.com/organization/98c34fb974ce445eac854de0/a64c6aad9b0d61ef6c0290bd?card=NAV-12267)