### PR TITLE
Reduser cpu request. Øker minne request i prod

### DIFF
--- a/.deploy/nais-dev.yaml
+++ b/.deploy/nais-dev.yaml
@@ -27,7 +27,7 @@ spec:
       memory: 256Mi
     requests:
       memory: 256Mi
-      cpu: 500m
+      cpu: 2m
   secureLogs:
     enabled: true
   ingresses:

--- a/.deploy/nais-prod.yaml
+++ b/.deploy/nais-prod.yaml
@@ -28,6 +28,7 @@ spec:
     requests:
       memory: 256Mi
       cpu: 500m
+      cpu: 5m
   secureLogs:
     enabled: true
   ingresses:

--- a/.deploy/nais-prod.yaml
+++ b/.deploy/nais-prod.yaml
@@ -26,8 +26,7 @@ spec:
     limits:
       memory: 512Mi
     requests:
-      memory: 256Mi
-      cpu: 500m
+      memory: 384Mi
       cpu: 5m
   secureLogs:
     enabled: true


### PR DESCRIPTION
Ser at familie-ef-proxy spør om ekstremt mye mer cpu enn det den faktisk bruker. Reduser forespurt cpu til 1% av det vi hadde i prod og 0.5% av det vi hadde i dev.

I tillegg ser jeg at vi ber om mindre minne enn det vi bruker i prod. Det kan være uheldig da kubernetes må drepe en applikasjon dersom appene bruker mer minne enn maskinen de kjører på har. Dette gjelder ikke for cpu da man alltid kan throttle den applikasjonen som bruker mer enn de requester. Øker requested minne med 50%.

Prod:
<img width="1478" alt="image" src="https://github.com/navikt/familie-ef-proxy/assets/17828446/f5465b35-cf4f-4a4b-9116-0c82f6393850">

Dev:
<img width="1484" alt="image" src="https://github.com/navikt/familie-ef-proxy/assets/17828446/d8bee3e4-c919-482a-98a1-e2bf94de67ca">

