### PR TITLE
Legg til rettighetspakke i header ved kall mot Sigrun

### DIFF
--- a/src/main/kotlin/no/nav/familie/ef/proxy/api/ApiExceptionHandler.kt
+++ b/src/main/kotlin/no/nav/familie/ef/proxy/api/ApiExceptionHandler.kt
@@ -1,6 +1,5 @@
 package no.nav.familie.ef.proxy.api
 
-import java.nio.channels.ClosedChannelException
 import no.nav.security.token.support.spring.validation.interceptor.JwtTokenUnauthorizedException
 import org.slf4j.LoggerFactory
 import org.springframework.core.NestedExceptionUtils
@@ -16,6 +15,7 @@ import org.springframework.web.bind.annotation.ExceptionHandler
 import org.springframework.web.bind.annotation.ResponseStatus
 import org.springframework.web.context.request.WebRequest
 import org.springframework.web.servlet.mvc.method.annotation.ResponseEntityExceptionHandler
+import java.nio.channels.ClosedChannelException
 import java.util.concurrent.TimeoutException
 
 @Suppress("unused")

--- a/src/main/kotlin/no/nav/familie/ef/proxy/sigrun/SigrunClient.kt
+++ b/src/main/kotlin/no/nav/familie/ef/proxy/sigrun/SigrunClient.kt
@@ -23,6 +23,7 @@ class SigrunClient(
         headers.set("Nav-Personident", personIdent)
         headers.set("norskident", personIdent) // Kan fjernes når pensjonsgivende inntekt er tilgjengelig i Dolly og dermed ikke trenger å gå mot stub-endepunktet
         headers.set("inntektsaar", inntektsår.toString())
+        headers.set("rettighetspakke", "navEnsligForsoerger")
 
         return try {
             getForEntity(uriComponentsBuilder.build().toUri(), headers)

--- a/src/main/resources/application-dev.yml
+++ b/src/main/resources/application-dev.yml
@@ -12,7 +12,7 @@ CLUSTER_ENV: dev
 EF_SAK_URL: https://familie-ef-sak.intern.dev.nav.no
 EREG_URL: https://modapp-q2.adeo.no/ereg/api/v1/organisasjon
 INNTEKT_URL: https://app-q2.adeo.no/inntektskomponenten-ws/rs/api
-SIGRUN_URL: https://sigrun-skd-stub.dev.adeo.no/api
+SIGRUN_URL: https://sigrun.dev.adeo.no/api
 ARBEID_INNTEKT_URL: https://arbeid-og-inntekt.dev.adeo.no
 STS_URL: https://security-token-service.nais.preprod.local/rest/v1/sts/token
 EF_PERSONHENDELSE_CLIENT_ID: dev-gcp:teamfamilie:familie-ef-personhendelse


### PR DESCRIPTION
Legger til ny header med navn "rettighetspakke" som følge av krav fra skatt/sigrun som skal brukes til tilgangskontroll, ref: https://jira.adeo.no/browse/REG-11739

Tester i preprod før merge.

[Favro](https://favro.com/organization/98c34fb974ce445eac854de0/a64c6aad9b0d61ef6c0290bd?card=NAV-19990)