### PR TITLE
Distroless

### DIFF
--- a/.deploy/nais-dev.yaml
+++ b/.deploy/nais-dev.yaml
@@ -33,13 +33,6 @@ spec:
   ingresses:
     - https://familie-ef-proxy.dev.intern.nav.no
     - https://familie-ef-proxy.dev-fss-pub.nais.io
-  vault:
-    enabled: true
-    paths:
-      - kvPath: /serviceuser/data/dev/srvfamilie-ef-sak
-        mountPath: /var/run/secrets/serviceuser/efsak
-      - kvPath: /serviceuser/data/dev/srvfamilie-ef-person
-        mountPath: /var/run/secrets/serviceuser/personhendelse
   azure:
     application:
       enabled: true

--- a/.deploy/nais-dev.yaml
+++ b/.deploy/nais-dev.yaml
@@ -69,3 +69,5 @@ spec:
   env:
     - name: SPRING_PROFILES_ACTIVE
       value: dev
+    - name: JDK_JAVA_OPTIONS
+      value: $(JAVA_PROXY_OPTIONS)

--- a/.deploy/nais-dev.yaml
+++ b/.deploy/nais-dev.yaml
@@ -8,6 +8,7 @@ metadata:
 
 spec:
   image: {{ image }}
+  webproxy: true
   liveness:
     path: /internal/status/isAlive
     initialDelay: 30

--- a/.deploy/nais-dev.yaml
+++ b/.deploy/nais-dev.yaml
@@ -62,7 +62,5 @@ spec:
   env:
     - name: SPRING_PROFILES_ACTIVE
       value: dev
-    - name: JDK_JAVA_OPTIONS
-      value: "-XX:MaxRAMPercentage=75"
   envFrom:
     - secret: familie-ef-proxy-serviceusers

--- a/.deploy/nais-dev.yaml
+++ b/.deploy/nais-dev.yaml
@@ -69,5 +69,3 @@ spec:
   env:
     - name: SPRING_PROFILES_ACTIVE
       value: dev
-    - name: JDK_JAVA_OPTIONS
-      value: $(JAVA_PROXY_OPTIONS)

--- a/.deploy/nais-dev.yaml
+++ b/.deploy/nais-dev.yaml
@@ -70,6 +70,6 @@ spec:
     - name: SPRING_PROFILES_ACTIVE
       value: dev
     - name: JDK_JAVA_OPTIONS
-      value: $(JAVA_PROXY_OPTIONS)
+      value: "$(JAVA_PROXY_OPTIONS)"
   envFrom:
     - secret: familie-ef-proxy-serviceusers

--- a/.deploy/nais-dev.yaml
+++ b/.deploy/nais-dev.yaml
@@ -69,3 +69,7 @@ spec:
   env:
     - name: SPRING_PROFILES_ACTIVE
       value: dev
+    - name: JDK_JAVA_OPTIONS
+      value: $(JAVA_PROXY_OPTIONS)
+  envFrom:
+    - secret: familie-ef-proxy-serviceusers

--- a/.deploy/nais-dev.yaml
+++ b/.deploy/nais-dev.yaml
@@ -8,7 +8,6 @@ metadata:
 
 spec:
   image: {{ image }}
-  webproxy: true
   liveness:
     path: /internal/status/isAlive
     initialDelay: 30
@@ -71,6 +70,6 @@ spec:
     - name: SPRING_PROFILES_ACTIVE
       value: dev
     - name: JDK_JAVA_OPTIONS
-      value: "$(JAVA_PROXY_OPTIONS) -XX:MaxRAMPercentage=75"
+      value: "-XX:MaxRAMPercentage=75"
   envFrom:
     - secret: familie-ef-proxy-serviceusers

--- a/.deploy/nais-dev.yaml
+++ b/.deploy/nais-dev.yaml
@@ -70,6 +70,6 @@ spec:
     - name: SPRING_PROFILES_ACTIVE
       value: dev
     - name: JDK_JAVA_OPTIONS
-      value: "$(JAVA_OPTS)"
+      value: "$(JAVA_PROXY_OPTIONS) -XX:MaxRAMPercentage=75"
   envFrom:
     - secret: familie-ef-proxy-serviceusers

--- a/.deploy/nais-dev.yaml
+++ b/.deploy/nais-dev.yaml
@@ -70,6 +70,6 @@ spec:
     - name: SPRING_PROFILES_ACTIVE
       value: dev
     - name: JDK_JAVA_OPTIONS
-      value: "$(JAVA_PROXY_OPTIONS)"
+      value: "$(JAVA_OPTS)"
   envFrom:
     - secret: familie-ef-proxy-serviceusers

--- a/.deploy/nais-prod.yaml
+++ b/.deploy/nais-prod.yaml
@@ -66,3 +66,7 @@ spec:
   env:
     - name: SPRING_PROFILES_ACTIVE
       value: prod
+    - name: JDK_JAVA_OPTIONS
+      value: "-XX:MaxRAMPercentage=75"
+  envFrom:
+    - secret: familie-ef-proxy-serviceusers

--- a/.deploy/nais-prod.yaml
+++ b/.deploy/nais-prod.yaml
@@ -33,13 +33,6 @@ spec:
   ingresses:
     - https://familie-ef-proxy.intern.nav.no
     - https://familie-ef-proxy.prod-fss-pub.nais.io
-  vault:
-    enabled: true
-    paths:
-      - kvPath: /serviceuser/data/prod/srvfamilie-ef-sak
-        mountPath: /var/run/secrets/serviceuser/efsak
-      - kvPath: /serviceuser/data/prod/srvfamilie-ef-person
-        mountPath: /var/run/secrets/serviceuser/personhendelse
   azure:
     application:
       enabled: true

--- a/.deploy/nais-prod.yaml
+++ b/.deploy/nais-prod.yaml
@@ -59,7 +59,5 @@ spec:
   env:
     - name: SPRING_PROFILES_ACTIVE
       value: prod
-    - name: JDK_JAVA_OPTIONS
-      value: "-XX:MaxRAMPercentage=75"
   envFrom:
     - secret: familie-ef-proxy-serviceusers

--- a/Dockerfile
+++ b/Dockerfile
@@ -9,4 +9,4 @@ ENV APP_NAME=familie-ef-proxy
 ENV JAVA_OPTS="-XX:MaxRAMPercentage=75"
 
 COPY ./target/familie-ef-proxy.jar /app/app.jar
-CMD ["-jar", "/app/app.jar"]
+ENTRYPOINT ["java", "-jar", "/app/app.jar"]

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,6 +1,9 @@
-FROM ghcr.io/navikt/baseimages/temurin:21
-
+FROM gcr.io/distroless/java21-debian12
+LABEL maintainer="PO Familie - Enslig forsørger"
+ENV LC_ALL='nb_NO.UTF-8'
+ENV TZ='Europe/Oslo'
 ENV APP_NAME=familie-ef-proxy
 ENV JAVA_OPTS="-XX:MaxRAMPercentage=75"
+
 COPY init.sh /init-scripts/init.sh
 COPY ./target/familie-ef-proxy.jar "app.jar"

--- a/Dockerfile
+++ b/Dockerfile
@@ -7,3 +7,4 @@ ENV JAVA_OPTS="-XX:MaxRAMPercentage=75"
 
 COPY init.sh /init-scripts/init.sh
 COPY ./target/familie-ef-proxy.jar "app.jar"
+CMD ["-jar", "/app/app.jar"]

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,5 +1,8 @@
 FROM gcr.io/distroless/java21-debian12:nonroot
 LABEL maintainer="PO Familie - Enslig forsørger"
+
+ENV LANG='nb_NO.UTF-8'
+ENV LANGUAGE='nb_NO:nb'
 ENV LC_ALL='nb_NO.UTF-8'
 ENV TZ='Europe/Oslo'
 ENV APP_NAME=familie-ef-proxy

--- a/Dockerfile
+++ b/Dockerfile
@@ -6,5 +6,5 @@ ENV APP_NAME=familie-ef-proxy
 ENV JAVA_OPTS="-XX:MaxRAMPercentage=75"
 
 COPY init.sh /init-scripts/init.sh
-COPY ./target/familie-ef-proxy.jar "app.jar"
+COPY ./target/familie-ef-proxy.jar /app/app.jar
 CMD ["-jar", "/app/app.jar"]

--- a/Dockerfile
+++ b/Dockerfile
@@ -6,6 +6,6 @@ ENV LANGUAGE='nb_NO:nb'
 ENV LC_ALL='nb_NO.UTF-8'
 ENV TZ='Europe/Oslo'
 ENV APP_NAME=familie-ef-proxy
-
+ENV JDK_JAVA_OPTIONS="-XX:MaxRAMPercentage=75"
 COPY ./target/familie-ef-proxy.jar /app/app.jar
 ENTRYPOINT ["java", "-jar", "/app/app.jar"]

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,10 +1,9 @@
-FROM gcr.io/distroless/java21-debian12
+FROM gcr.io/distroless/java21-debian12:nonroot
 LABEL maintainer="PO Familie - Enslig forsørger"
 ENV LC_ALL='nb_NO.UTF-8'
 ENV TZ='Europe/Oslo'
 ENV APP_NAME=familie-ef-proxy
 ENV JAVA_OPTS="-XX:MaxRAMPercentage=75"
 
-COPY init.sh /init-scripts/init.sh
 COPY ./target/familie-ef-proxy.jar /app/app.jar
 CMD ["-jar", "/app/app.jar"]

--- a/Dockerfile
+++ b/Dockerfile
@@ -6,7 +6,6 @@ ENV LANGUAGE='nb_NO:nb'
 ENV LC_ALL='nb_NO.UTF-8'
 ENV TZ='Europe/Oslo'
 ENV APP_NAME=familie-ef-proxy
-ENV JAVA_OPTS="-XX:MaxRAMPercentage=75"
 
 COPY ./target/familie-ef-proxy.jar /app/app.jar
 ENTRYPOINT ["java", "-jar", "/app/app.jar"]

--- a/init.sh
+++ b/init.sh
@@ -1,6 +1,0 @@
-#!/bin/sh
-echo "running init.sh script"
-export CREDENTIAL_USERNAME=$(cat /var/run/secrets/serviceuser/efsak/username)
-export CREDENTIAL_PASSWORD=$(cat /var/run/secrets/serviceuser/efsak/password)
-export SRVUSERNAME_EF_PERSONHENDELSE=$(cat /var/run/secrets/serviceuser/personhendelse/username)
-export SRVPASSWORD_EF_PERSONHENDELSE=$(cat /var/run/secrets/serviceuser/personhendelse/password)


### PR DESCRIPTION
Byttet til distroless image. 
Fulgte anbefalt oppsett: https://sikkerhet.nav.no/docs/sikker-utvikling/containere#distroless i tillegg til hjelp fra teamet og slack.

Benyttet muligheten til å gå vekk fra vault, da det er anbefalt av nais, i tillegg til at det uansett ville krevd mer config med et distroless image. Secrets er lagt i kubernetes secrets i `familie-ef-proxy-serviceusers` - gjerne dobbeltsjekk om verdiene ser riktige ut i dev og prod som en del av PR.

Testet av inntekt-kall (Sigrun) går fint. 