### PR TITLE
Opprydding i InntektV2 implementasjon

### DIFF
--- a/src/main/kotlin/no/nav/familie/ef/proxy/api/InntektController.kt
+++ b/src/main/kotlin/no/nav/familie/ef/proxy/api/InntektController.kt
@@ -1,14 +1,12 @@
 package no.nav.familie.ef.proxy.api
 
 import no.nav.familie.ef.proxy.integration.InntektClient
-import no.nav.familie.kontrakter.felles.PersonIdent
 import no.nav.security.token.support.core.api.ProtectedWithClaims
 import org.springframework.http.MediaType
 import org.springframework.validation.annotation.Validated
 import org.springframework.web.bind.annotation.PostMapping
 import org.springframework.web.bind.annotation.RequestBody
 import org.springframework.web.bind.annotation.RequestMapping
-import org.springframework.web.bind.annotation.RequestParam
 import org.springframework.web.bind.annotation.RestController
 import java.time.YearMonth
 
@@ -24,30 +22,18 @@ class InntektController(
     private val inntektClient: InntektClient,
 ) {
     @PostMapping("v2")
-    fun hentInntektV2(
+    fun hentInntekt(
         @RequestBody inntektV2Request: InntektV2Request,
     ): Map<String, Any> =
         inntektClient.hentInntekt(
-            personIdent = inntektV2Request.personident,
-            maanedFom = inntektV2Request.maanedFom ?: YearMonth.now().minusMonths(2),
-            maanedTom = inntektV2Request.maanedTom ?: YearMonth.now(),
-        )
-
-    @PostMapping("/historikk")
-    fun hentInntektshistorikk(
-        @RequestBody request: PersonIdent,
-        @RequestParam("fom", required = false) fom: YearMonth?,
-        @RequestParam("tom", required = false) tom: YearMonth?,
-    ): Map<String, Any> =
-        inntektClient.hentInntektshistorikk(
-            personIdent = request.ident,
-            fom = fom ?: YearMonth.now().minusMonths(12),
-            tom = tom ?: YearMonth.now(),
+            personIdent = inntektV2Request.personIdent,
+            maanedFom = inntektV2Request.månedFom ?: YearMonth.now().minusMonths(2),
+            maanedTom = inntektV2Request.månedTom ?: YearMonth.now(),
         )
 }
 
 data class InntektV2Request(
-    val personident: String,
-    val maanedFom: YearMonth?,
-    val maanedTom: YearMonth?,
+    val personIdent: String,
+    val månedFom: YearMonth?,
+    val månedTom: YearMonth?,
 )

--- a/src/main/kotlin/no/nav/familie/ef/proxy/api/InntektController.kt
+++ b/src/main/kotlin/no/nav/familie/ef/proxy/api/InntektController.kt
@@ -23,23 +23,11 @@ import java.time.YearMonth
 class InntektController(
     private val inntektClient: InntektClient,
 ) {
-    @PostMapping
-    fun hentInntekt(
-        @RequestBody request: PersonIdent,
-        @RequestParam("fom", required = false) fom: YearMonth?,
-        @RequestParam("tom", required = false) tom: YearMonth?,
-    ): Map<String, Any> =
-        inntektClient.hentInntekt(
-            personIdent = request.ident,
-            fom = fom ?: YearMonth.now().minusMonths(2),
-            tom = tom ?: YearMonth.now(),
-        )
-
     @PostMapping("v2")
     fun hentInntektV2(
         @RequestBody inntektV2Request: InntektV2Request,
     ): Map<String, Any> =
-        inntektClient.hentInntektV2(
+        inntektClient.hentInntekt(
             personIdent = inntektV2Request.personident,
             maanedFom = inntektV2Request.maanedFom ?: YearMonth.now().minusMonths(2),
             maanedTom = inntektV2Request.maanedTom ?: YearMonth.now(),

--- a/src/main/kotlin/no/nav/familie/ef/proxy/api/InntektController.kt
+++ b/src/main/kotlin/no/nav/familie/ef/proxy/api/InntektController.kt
@@ -27,8 +27,8 @@ class InntektController(
     ): Map<String, Any> =
         inntektClient.hentInntekt(
             personIdent = inntektV2Request.personIdent,
-            maanedFom = inntektV2Request.månedFom ?: YearMonth.now().minusMonths(2),
-            maanedTom = inntektV2Request.månedTom ?: YearMonth.now(),
+            månedFom = inntektV2Request.månedFom ?: YearMonth.now().minusMonths(2),
+            månedTom = inntektV2Request.månedTom ?: YearMonth.now(),
         )
 }
 

--- a/src/main/kotlin/no/nav/familie/ef/proxy/integration/InntektClient.kt
+++ b/src/main/kotlin/no/nav/familie/ef/proxy/integration/InntektClient.kt
@@ -28,14 +28,14 @@ class InntektClient(
 
     fun hentInntekt(
         personIdent: String,
-        maanedFom: YearMonth,
-        maanedTom: YearMonth,
+        månedFom: YearMonth,
+        månedTom: YearMonth,
     ): Map<String, Any> {
         val request =
             genererInntektRequest(
                 personIdent = personIdent,
-                månedFom = maanedFom,
-                månedTom = maanedTom,
+                månedFom = månedFom,
+                månedTom = månedTom,
             )
 
         val payload = objectMapper.writeValueAsString(request)

--- a/src/main/kotlin/no/nav/familie/ef/proxy/integration/InntektClient.kt
+++ b/src/main/kotlin/no/nav/familie/ef/proxy/integration/InntektClient.kt
@@ -16,14 +16,12 @@ import java.time.YearMonth
 class InntektClient(
     @Value("\${INNTEKT_URL}")
     private val uri: URI,
-    @Value("\${INNTEKTV2_URL}")
-    private val inntektV2Uri: URI,
     private val stsClient: StsClient,
     @Qualifier("noToken") restOperations: RestOperations,
 ) : AbstractRestClient(restOperations, "inntekt") {
-    private val inntektUri =
+    private val inntektV2Uri =
         UriComponentsBuilder
-            .fromUri(inntektV2Uri)
+            .fromUri(uri)
             .pathSegment("inntekt")
             .build()
             .toUri()
@@ -44,7 +42,7 @@ class InntektClient(
 
         val entity =
             postForEntity<Map<String, Any>>(
-                uri = inntektUri,
+                uri = inntektV2Uri,
                 payload = payload,
                 httpHeaders =
                     headers(
@@ -53,23 +51,6 @@ class InntektClient(
             )
 
         return entity
-    }
-
-    fun hentInntektshistorikk(
-        personIdent: String,
-        fom: YearMonth,
-        tom: YearMonth,
-    ): Map<String, Any> {
-        val inntektshistorikkUri =
-            UriComponentsBuilder
-                .fromUri(uri)
-                .pathSegment("v1/inntektshistorikk")
-                .queryParam("maaned-fom", fom)
-                .queryParam("maaned-tom", tom)
-                .queryParam("filter", "StoenadEnsligMorEllerFarA-inntekt")
-                .build()
-                .toUri()
-        return getForEntity(inntektshistorikkUri, headers(stsClient.hentStsToken().token))
     }
 
     private fun genererInntektRequest(
@@ -84,9 +65,7 @@ class InntektClient(
         "maanedTom" to maanedTom,
     )
 
-    private fun headers(
-        token: String,
-    ): HttpHeaders =
+    private fun headers(token: String): HttpHeaders =
         HttpHeaders().apply {
             setBearerAuth(token)
             contentType = MediaType.APPLICATION_JSON

--- a/src/main/kotlin/no/nav/familie/ef/proxy/integration/InntektClient.kt
+++ b/src/main/kotlin/no/nav/familie/ef/proxy/integration/InntektClient.kt
@@ -34,8 +34,8 @@ class InntektClient(
         val request =
             genererInntektRequest(
                 personIdent = personIdent,
-                maanedFom = maanedFom,
-                maanedTom = maanedTom,
+                månedFom = maanedFom,
+                månedTom = maanedTom,
             )
 
         val payload = objectMapper.writeValueAsString(request)
@@ -55,14 +55,14 @@ class InntektClient(
 
     private fun genererInntektRequest(
         personIdent: String,
-        maanedFom: YearMonth,
-        maanedTom: YearMonth,
+        månedFom: YearMonth,
+        månedTom: YearMonth,
     ) = mapOf(
         "personident" to personIdent,
         "filter" to "StoenadEnsligMorEllerFarA-inntekt",
         "formaal" to "StoenadEnsligMorEllerFar",
-        "maanedFom" to maanedFom,
-        "maanedTom" to maanedTom,
+        "maanedFom" to månedFom,
+        "maanedTom" to månedTom,
     )
 
     private fun headers(token: String): HttpHeaders =

--- a/src/main/resources/application-dev.yml
+++ b/src/main/resources/application-dev.yml
@@ -11,8 +11,7 @@ no.nav.security.jwt:
 CLUSTER_ENV: dev
 EF_SAK_URL: https://familie-ef-sak.intern.dev.nav.no
 EREG_URL: https://ereg-services.intern.dev.nav.no/v1/organisasjon
-INNTEKT_URL: https://app-q2.adeo.no/inntektskomponenten-ws/rs/api
-INNTEKTV2_URL: https://wasapp-q2.adeo.no/inntektskomponenten-ws/rest/v2
+INNTEKT_URL: https://wasapp-q2.adeo.no/inntektskomponenten-ws/rest/v2
 SIGRUN_URL: https://sigrun-q2.dev.adeo.no/api
 ARBEID_INNTEKT_URL: https://arbeid-og-inntekt.dev.adeo.no
 STS_URL: https://security-token-service.nais.preprod.local/rest/v1/sts/token

--- a/src/main/resources/application.yml
+++ b/src/main/resources/application.yml
@@ -55,8 +55,7 @@ springdoc:
 CLUSTER_ENV: prod
 EF_SAK_URL: https://familie-ef-sak.intern.nav.no
 EREG_URL: https://ereg-services.intern.nav.no/v1/organisasjon
-INNTEKT_URL: https://app.adeo.no/inntektskomponenten-ws/rs/api
-INNTEKTV2_URL: https://app.adeo.no/inntektskomponenten-ws/rest/v2
+INNTEKT_URL: https://app.adeo.no/inntektskomponenten-ws/rest/v2
 SIGRUN_URL: https://sigrun.nais.adeo.no/api/
 ARBEID_INNTEKT_URL: https://arbeid-og-inntekt.nais.adeo.no
 SIGRUN_SCOPE: api://${CLUSTER_ENV}-fss.team-inntekt.sigrun/.default

--- a/src/test/resources/application-integrasjonstest.yaml
+++ b/src/test/resources/application-integrasjonstest.yaml
@@ -18,7 +18,6 @@ funksjonsbrytere:
 EF_SAK_URL: http://localhost:8385
 EREG_URL: http://localhost:8385
 INNTEKT_URL: http://localhost:8385
-INNTEKTV2_URRL: http://localhost:8385
 SIGRUN_URL: http://localhost:8385
 
 CREDENTIAL_USERNAME: not-a-real-srvuser


### PR DESCRIPTION
# Opprydding i InntektV2 implementasjon

### Hvorfor er denne endringen nødvendig? ✨ 

Denne PR-en tar for seg opprydding av implementasjonen til `InntektV2`. Den fjerner den eldre versjonen av `InntektV1` og legger føringer for delautomatiseringsarbeidet som er under arbeid. 

Oppgaven og beskrivelsen kan du finne på Favro → [her](https://favro.com/organization/98c34fb974ce445eac854de0/a64c6aad9b0d61ef6c0290bd?card=NAV-24309).

Denne PR-en er en del av en bredere oppgave og avhenger av disse PR-ene → [ef-sak](https://github.com/navikt/familie-ef-sak/pull/2790) og [ef-personhendelse](https://github.com/navikt/familie-ef-personhendelse/pull/583).

### Verdt å nevne

Denne PR-en, sammen med de andre, innfører store endringer. Hovedsakelig har datastrukturen for inntekt endret seg, og jeg har gjort mitt beste for å ta høyde for de nye endringene. Det er store endringer i prinsipiell forretningslogikk, samt store endringer for tester som allerede fantes.

Vi testet en dry-run mot prod, noe som viste seg å fungere.