### PR TITLE
Sett lik memory request og limit

### DIFF
--- a/.deploy/nais-dev.yaml
+++ b/.deploy/nais-dev.yaml
@@ -26,7 +26,7 @@ spec:
     limits:
       memory: 512Mi
     requests:
-      memory: 256Mi
+      memory: 512Mi
       cpu: 2m
   ingresses:
     - https://familie-ef-proxy.dev.intern.nav.no

--- a/.deploy/nais-prod.yaml
+++ b/.deploy/nais-prod.yaml
@@ -26,7 +26,7 @@ spec:
     limits:
       memory: 512Mi
     requests:
-      memory: 384Mi
+      memory: 512Mi
       cpu: 5m
   ingresses:
     - https://familie-ef-proxy.intern.nav.no


### PR DESCRIPTION
## Hva
Setter `resources.requests.memory` lik `resources.limits.memory` i nais.yaml-filene.

## Hvorfor
Anbefalt praksis for Kubernetes-ressurser er å ha requests og limits like for minne, se
https://www.flexera.com/blog/finops/kubernetes-limits-vs-requests-key-differences-and-how-they-work/#s5

Ingen CPU-limit er satt i denne appen, så det er ikke gjort endringer der.
