### PR TITLE
Juster ressurser etter Nais-anbefaling

### DIFF
--- a/.deploy/nais-dev.yaml
+++ b/.deploy/nais-dev.yaml
@@ -27,7 +27,7 @@ spec:
       memory: 512Mi
     requests:
       memory: 512Mi
-      cpu: 2m
+      cpu: 50m
   ingresses:
     - https://familie-ef-proxy.dev.intern.nav.no
     - https://familie-ef-proxy.dev-fss-pub.nais.io

--- a/.deploy/nais-prod.yaml
+++ b/.deploy/nais-prod.yaml
@@ -27,7 +27,7 @@ spec:
       memory: 512Mi
     requests:
       memory: 512Mi
-      cpu: 5m
+      cpu: 50m
   ingresses:
     - https://familie-ef-proxy.intern.nav.no
     - https://familie-ef-proxy.prod-fss-pub.nais.io


### PR DESCRIPTION
## Hva
Justerer CPU/memory requests og limits etter Nais console sine anbefalinger (basert på faktisk bruk). Forrige runde satte vi `memory request = limit`, men på de gamle høye verdiene, noe som ga over-reservering flagget som «dyrere ressurser enn forventet».

## Hvordan
- **Memory:** `request = limit` beholdt (Guaranteed QoS), satt til Nais sitt anbefalte limit avrundet til ren verdi.
- **CPU request** justert mot anbefaling. Ingen CPU-limit.